### PR TITLE
Read Multiple Modmail Conversations

### DIFF
--- a/config_sample.json
+++ b/config_sample.json
@@ -2,7 +2,7 @@
     "token": "Bot Token",
     "embedColor": "#7289DA",
     "secondOpinionColor": "#e91e63",
-    "modID": "Moderator Role ID",
+    "modID": ["Moderator Role ID 1","Moderator Role ID 2"],
     "communityID": "Community Role ID",
     "prefix": "!",
     "inviteID": "Welcome Channel ID for Invite Links",

--- a/index.js
+++ b/index.js
@@ -178,7 +178,14 @@ client.on('messageCreate', async (message) => {
 	if (!message.member) return;
 
 	// Ignore Messages that are not made by a user with Moderator Role or Community Role matched by ID
-	if (!(message.member.roles.cache.has(config.modID) || message.member.roles.cache.has(config.communityID))) return;
+	let isModId = false;
+	let isComID = false;
+
+	if (Array.isArray(config.modID)) for (let i = 0; i < config.modID.length; i++) if (message.member.roles.cache.has(config.modID[i])) isModId = true;
+	else if (message.member.roles.cache.has(config.modID)) isModId = true;
+	if (message.member.roles.cache.has(config.communityID)) isComID = true;
+
+	if (!isModId && !isComID) return;
 
 	/** START Command Logic */
 	const args = message.content.slice(config.prefix.length).trim().split(/ +/)


### PR DESCRIPTION
getModMail function has been updated to fetch the 10 most recent **not** archived Modmail Conversations
The bot will also fetch the first post of any given conversation

snoowrap should ignore archived conversations

Note: I have removed the escape condition set for some users, this mostly means that it will no longer ignore messages sent into Modmail if it was _originally_ authored by those users. This should not cause any functional change.